### PR TITLE
Bumping Mesos version to 24

### DIFF
--- a/mesos-common/Dockerfile
+++ b/mesos-common/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && \
 	apt-get clean
 
 RUN mkdir -p /opt/mesos
-RUN wget -q -O - https://github.com/apache/mesos/archive/0.23.0.tar.gz | \
+RUN wget -q -O - https://github.com/apache/mesos/archive/0.24.0.tar.gz | \
 	tar -xzf - -C /opt/mesos --strip=1
 
 WORKDIR /opt/mesos


### PR DESCRIPTION
Build is OK and tests pass with newest version
