### PR TITLE
don't build the mesos rpm, just use the official mesos package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,3 @@
-MESOS_VER=0.26.0
-MESOS_HELPER_URL=https://codeload.github.com/danigiri/mesos-build-helper/zip/$(MESOS_VER) 
-
 all: build compose
 
 build: build-common build-zookeeper build-mesos-common build-mesos-master build-mesos-slave \
@@ -12,13 +9,7 @@ build-common:
 build-zookeeper: build-common
 	cd zookeeper && docker build -t mesoscope/zookeeper .
 
-mesos-common/mesos-$(MESOS_VER)-1.x86_64.rpm:
-	mkdir -p tmp && cd tmp && curl -s -S "$(MESOS_HELPER_URL)" -o mesos-build-helper-$(MESOS_VER).zip
-	unzip -q -u tmp/mesos-build-helper-$(MESOS_VER).zip -d tmp
-	DOCKER_FILE=Dockerfile-ubuntu cd tmp/mesos-build-helper-$(MESOS_VER) && source ./script/build
-	cp -v tmp/mesos-build-helper-$(MESOS_VER)/mesos-$(MESOS_VER)-1.x86_64.rpm mesos-common
-
-build-mesos-common: build-common mesos-common/mesos-$(MESOS_VER)-1.x86_64.rpm
+build-mesos-common:
 	cd mesos-common && docker build -t mesoscope/mesos-common .
 
 build-mesos-master: build-mesos-common

--- a/mesos-common/Dockerfile
+++ b/mesos-common/Dockerfile
@@ -2,34 +2,11 @@
 
 FROM mesoscope/common
 
-ENV MESOS_PACKAGE mesos-0.26.0-1.x86_64.rpm 
-
-# following this http://mesos.apache.org/gettingstarted/
 RUN apt-get update && \
-	apt-get install -y --no-install-recommends build-essential \
-		python-boto libcurl4-nss-dev libsasl2-dev libapr1-dev libsvn-dev \
-		autoconf automake libtool libsasl2-modules && \
-	apt-get install -y --no-install-recommends rpm && \
+	apt-get install -y --no-install-recommends libcurl3 libsvn1 libsasl2-modules && \
 	apt-get clean
 
-# TODO: check when sasl has latest and remove this
-# .deb repos have version .25 which does not install libsasl2.so.3
-RUN wget ftp://ftp.cyrusimap.org/cyrus-sasl/cyrus-sasl-2.1.26.tar.gz
-RUN tar zxf cyrus-sasl-2.1.26.tar.gz && cd cyrus-sasl-2.1.26 && \
-	./configure CC=gcc-4.8 CPPFLAGS=-I/usr/include/openssl --enable-cram && \
-	make && \
-	make install
-RUN rm -f cyrus-sasl-2.1.26.tar.gz
-RUN rm -rf cyrus-sasl-2.1.26
-
-# TODO: fix this hack
-# .deb repos have slightly different dependency linking names
-RUN cd /usr/lib/x86_64-linux-gnu && \
-	ln -s libsvn_delta-1.so.1.0.0 libsvn_delta-1.so.0 && \
-	ln -s libsvn_subr-1.so.1.0.0 libsvn_subr-1.so.0 && \
-	ln -s libcurl-nss.so libcurl.so.4
-
-COPY ${MESOS_PACKAGE} .
-RUN rpm -ivh --nodeps ${MESOS_PACKAGE} && \
- rm -f ${MESOS_PACKAGE}
+RUN wget -q http://downloads.mesosphere.io/master/ubuntu/14.04/mesos_0.26.0-0.2.145.ubuntu1404_amd64.deb && \
+    dpkg -i mesos_0.26.0-0.2.145.ubuntu1404_amd64.deb && \
+    rm mesos_0.26.0-0.2.145.ubuntu1404_amd64.deb
 


### PR DESCRIPTION
It's faster and easier!

In a clean environment (a clean local registry with no local images and no already downloaded packages), the `make build` command takes just 5 minutes!

also, it allows you to add a container for aurora in the future without building the aurora package yourself and just using the official deb package
