### PR TITLE
Couple of fixes and versioning changes 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-MESOS_VER=0.27.1
-MESOS_HELPER_URL=https://codeload.github.com/danigiri/mesos-build-helper/zip/$(MESOS_VER) 
+MESOS_VER=0.28.2
+MESOS_HELPER_URL=https://codeload.github.com/dcaba/mesos-build-helper/zip/$(MESOS_VER) 
 
 all: build compose
 
@@ -19,7 +19,7 @@ mesos-common/mesos-$(MESOS_VER)-1.x86_64.rpm:
 	cp -v tmp/mesos-build-helper-$(MESOS_VER)/mesos-$(MESOS_VER)-1.x86_64.rpm mesos-common
 
 build-mesos-common: build-common mesos-common/mesos-$(MESOS_VER)-1.x86_64.rpm
-	cd mesos-common && docker build -t mesoscope/mesos-common .
+	cd mesos-common && docker build --build-arg mesos_ver=$(MESOS_VER) -t mesoscope/mesos-common .
 
 build-mesos-master: build-mesos-common
 	cd mesos-master && docker build -t mesoscope/mesos-master .

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-MESOS_VER=0.28.2
+export MESOS_VER=0.28.2
 MESOS_HELPER_URL=https://codeload.github.com/dcaba/mesos-build-helper/zip/$(MESOS_VER) 
 
 all: build compose
@@ -14,7 +14,7 @@ build-zookeeper: build-common
 
 mesos-common/mesos-$(MESOS_VER)-1.x86_64.rpm:
 	mkdir -p tmp && cd tmp && curl -s -S "$(MESOS_HELPER_URL)" -o mesos-build-helper-$(MESOS_VER).zip
-	unzip -q -u tmp/mesos-build-helper-$(MESOS_VER).zip -d tmp
+	unzip -q -o -u tmp/mesos-build-helper-$(MESOS_VER).zip -d tmp
 	DOCKER_FILE=Dockerfile-ubuntu cd tmp/mesos-build-helper-$(MESOS_VER) && ./script/build
 	cp -v tmp/mesos-build-helper-$(MESOS_VER)/mesos-$(MESOS_VER)-1.x86_64.rpm mesos-common
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 export MESOS_VER=0.28.2
-MESOS_HELPER_URL=https://codeload.github.com/dcaba/mesos-build-helper/zip/$(MESOS_VER) 
+MESOS_HELPER_URL=https://codeload.github.com/danigiri/mesos-build-helper/zip/$(MESOS_VER) 
 
 all: build compose
 

--- a/docker-registry/Dockerfile
+++ b/docker-registry/Dockerfile
@@ -2,7 +2,7 @@
 
 FROM mesoscope/common
 
-ENV GOLANG_VERSION="1.5.2.linux-amd64"
+ENV GOLANG_VERSION="1.6.3.linux-amd64"
 ENV GOPATH="/go"
 ENV PATH="$GOPATH/bin:/usr/local/go/bin:$PATH"
 ENV SRVPATH="/opt/docker-registry"
@@ -17,8 +17,7 @@ RUN curl -sSL https://golang.org/dl/go${GOLANG_VERSION}.tar.gz | \
 RUN mkdir -p ${GOPATH}
 RUN go get -x github.com/tools/godep && \
 	go get -x golang.org/x/sys/unix && \
-	go get -x github.com/inconshreveable/mousetrap && \
-	godep get github.com/docker/distribution/registry
+	go get -x github.com/inconshreveable/mousetrap 
 
 RUN mkdir -p ${SRVPATH}/conf ${SRVPATH}/data
 ADD files/config.yml ${SRVPATH}/conf/config.yml

--- a/mesos-common/Dockerfile
+++ b/mesos-common/Dockerfile
@@ -2,7 +2,9 @@
 
 FROM mesoscope/common
 
-ENV MESOS_PACKAGE mesos-0.27.1-1.x86_64.rpm 
+ARG mesos_ver=0.28.2
+
+ENV MESOS_PACKAGE mesos-${mesos_ver}-1.x86_64.rpm 
 
 # following this http://mesos.apache.org/gettingstarted/
 RUN apt-get update && \

--- a/testapp/testapp.json
+++ b/testapp/testapp.json
@@ -6,7 +6,7 @@
 	"container": {
 		"type": "DOCKER",
 		"docker": {
-			"image": "dockermachine-vm:5000/testapp:latest",
+			"image": "dockermachine-vm:5000/testapp:1",
 			"network": "BRIDGE",
 			"portMappings": [
 				{ "containerPort": 8001, "hostPort": 0, "servicePort": 8001, "protocol": "tcp" }

--- a/zookeeper/Dockerfile
+++ b/zookeeper/Dockerfile
@@ -4,7 +4,7 @@
 FROM mesoscope/common
 
 RUN mkdir -p /opt/zookeeper /tmp/zookeeper
-RUN wget -q -O - http://www.eu.apache.org/dist/zookeeper/stable/zookeeper-3.4.8.tar.gz | \
+RUN wget -q -O - http://www.eu.apache.org/dist/zookeeper/zookeeper-3.4.8/zookeeper-3.4.8.tar.gz | \
 	tar -xzf - -C /opt/zookeeper --strip=1
 RUN cp /opt/zookeeper/conf/zoo_sample.cfg /opt/zookeeper/conf/zoo.cfg
 


### PR DESCRIPTION
Small staff, but fixes that were blocking a clean installation:
- pointing to a fork of the mesos build helper, as it currently points to an unavailable version of maven 
- and updating the mesos version to the latest 0.x, introducing some minor improvements to manage the actual version number (duplicated constants)
- and the docker registry is no longer working in 1.5 (requires a newer net/http). Updated and removing godep command (now it's vendoring all dependencies... and the ones it was originally pointing are no longer consistent)
